### PR TITLE
Add Hull Clustering search algorithm

### DIFF
--- a/energy_repset/__init__.py
+++ b/energy_repset/__init__.py
@@ -54,6 +54,7 @@ from .search_algorithms import (
     SearchAlgorithm,
     ObjectiveDrivenSearchAlgorithm,
     ObjectiveDrivenCombinatorialSearchAlgorithm,
+    HullClusteringSearch,
 )
 
 from .representation import (
@@ -105,6 +106,7 @@ __all__ = [
     "SearchAlgorithm",
     "ObjectiveDrivenSearchAlgorithm",
     "ObjectiveDrivenCombinatorialSearchAlgorithm",
+    "HullClusteringSearch",
     # Representation models
     "RepresentationModel",
     "UniformRepresentationModel",

--- a/energy_repset/search_algorithms/__init__.py
+++ b/energy_repset/search_algorithms/__init__.py
@@ -1,8 +1,10 @@
 from .search_algorithm import SearchAlgorithm
 from .objective_driven import ObjectiveDrivenSearchAlgorithm, ObjectiveDrivenCombinatorialSearchAlgorithm
+from .hull_clustering import HullClusteringSearch
 
 __all__ = [
     "SearchAlgorithm",
     "ObjectiveDrivenSearchAlgorithm",
     "ObjectiveDrivenCombinatorialSearchAlgorithm",
+    "HullClusteringSearch",
 ]

--- a/energy_repset/search_algorithms/hull_clustering.py
+++ b/energy_repset/search_algorithms/hull_clustering.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from typing import Literal, TYPE_CHECKING
+
+import numpy as np
+from scipy.optimize import minimize, nnls
+
+from .search_algorithm import SearchAlgorithm
+from ..results import RepSetResult
+
+if TYPE_CHECKING:
+    from ..context import ProblemContext
+
+
+class HullClusteringSearch(SearchAlgorithm):
+    """Greedy forward selection minimizing total projection error (Hull Clustering).
+
+    Implements the constructive hull clustering algorithm from Bahl et al. (2025).
+    At each iteration, the candidate that most reduces the total projection error
+    is added to the selection set. Each non-selected period is represented as a
+    convex or conic combination of the selected hull vertices.
+
+    The algorithm leaves ``weights=None`` in the result so that an external
+    ``RepresentationModel`` (typically ``BlendedRepresentationModel``) can compute
+    the final soft-assignment weights.
+
+    Args:
+        k: Number of representative periods to select.
+        hull_type: Type of projection constraint. ``'convex'`` enforces non-negative
+            weights that sum to 1. ``'conic'`` enforces only non-negativity.
+
+    Examples:
+        Basic usage with blended representation:
+
+        >>> from energy_repset.search_algorithms import HullClusteringSearch
+        >>> from energy_repset.representation import BlendedRepresentationModel
+        >>> search = HullClusteringSearch(k=4, hull_type='convex')
+        >>> repr_model = BlendedRepresentationModel(blend_type='convex')
+    """
+
+    def __init__(self, k: int, hull_type: Literal['convex', 'conic'] = 'convex'):
+        """Initialize Hull Clustering search.
+
+        Args:
+            k: Number of hull vertices (representative periods) to select.
+            hull_type: Projection type. ``'convex'`` requires weights >= 0 and
+                sum(weights) == 1. ``'conic'`` requires only weights >= 0.
+        """
+        self.k = k
+        self.hull_type = hull_type
+
+    def find_selection(self, context: ProblemContext) -> RepSetResult:
+        """Find k hull vertices via greedy forward selection.
+
+        Args:
+            context: Problem context with ``df_features`` populated.
+
+        Returns:
+            RepSetResult with the selected hull vertices, ``weights=None``
+            (to be filled by an external representation model), and the
+            final projection error in ``scores``.
+        """
+        Z = context.df_features.values
+        labels = list(context.df_features.index)
+        N, p = Z.shape
+
+        selected_idx: list[int] = []
+        remaining_idx = list(range(N))
+
+        for _ in range(self.k):
+            best_candidate = None
+            best_error = np.inf
+
+            for c in remaining_idx:
+                candidate_idx = selected_idx + [c]
+                error = self._total_projection_error(Z, candidate_idx)
+                if error < best_error:
+                    best_error = error
+                    best_candidate = c
+
+            selected_idx.append(best_candidate)
+            remaining_idx.remove(best_candidate)
+
+        final_error = self._total_projection_error(Z, selected_idx)
+        selection = tuple(labels[i] for i in selected_idx)
+
+        slice_labels = context.slicer.labels_for_index(context.df_raw.index)
+        representatives = {
+            s: context.df_raw.loc[slice_labels == s] for s in selection
+        }
+
+        return RepSetResult(
+            context=context,
+            selection_space='subset',
+            selection=selection,
+            scores={'projection_error': final_error},
+            representatives=representatives,
+            weights=None,
+        )
+
+    def _total_projection_error(
+        self, Z: np.ndarray, selected_idx: list[int]
+    ) -> float:
+        """Compute total reconstruction error across all periods.
+
+        Args:
+            Z: Full feature matrix (N x p).
+            selected_idx: Indices of currently selected hull vertices.
+
+        Returns:
+            Sum of squared reconstruction errors over all N periods.
+        """
+        Z_sel = Z[selected_idx]
+        total_error = 0.0
+        for i in range(Z.shape[0]):
+            total_error += self._projection_error(Z[i], Z_sel)
+        return total_error
+
+    def _projection_error(self, z: np.ndarray, Z_sel: np.ndarray) -> float:
+        """Compute minimum reconstruction error for a single period.
+
+        Args:
+            z: Feature vector for one period (length p).
+            Z_sel: Feature matrix of selected hull vertices (k_current x p).
+
+        Returns:
+            Squared L2 reconstruction error.
+        """
+        if self.hull_type == 'conic':
+            return self._projection_error_conic(z, Z_sel)
+        return self._projection_error_convex(z, Z_sel)
+
+    def _projection_error_conic(
+        self, z: np.ndarray, Z_sel: np.ndarray
+    ) -> float:
+        """Conic projection: min_w ||z - Z_sel^T @ w||^2, w >= 0."""
+        w, residual = nnls(Z_sel.T, z)
+        reconstruction = Z_sel.T @ w
+        return float(np.sum((z - reconstruction) ** 2))
+
+    def _projection_error_convex(
+        self, z: np.ndarray, Z_sel: np.ndarray
+    ) -> float:
+        """Convex projection: min_w ||z - Z_sel^T @ w||^2, w >= 0, sum(w) = 1."""
+        k_sel = Z_sel.shape[0]
+        if k_sel == 1:
+            return float(np.sum((z - Z_sel[0]) ** 2))
+
+        def objective(w):
+            return np.sum((z - w @ Z_sel) ** 2)
+
+        w0 = np.ones(k_sel) / k_sel
+        bounds = [(0.0, 1.0)] * k_sel
+        constraints = {'type': 'eq', 'fun': lambda w: np.sum(w) - 1.0}
+
+        result = minimize(
+            objective, w0, method='SLSQP',
+            bounds=bounds, constraints=constraints,
+            options={'ftol': 1e-10, 'maxiter': 200},
+        )
+        return float(result.fun)

--- a/tests/search_algorithms/test_hull_clustering.py
+++ b/tests/search_algorithms/test_hull_clustering.py
@@ -1,0 +1,78 @@
+"""Tests for Hull Clustering search algorithm."""
+import pytest
+
+from energy_repset.search_algorithms import HullClusteringSearch
+from energy_repset.representation import BlendedRepresentationModel
+from energy_repset.feature_engineering import StandardStatsFeatureEngineer
+from energy_repset.workflow import Workflow
+from energy_repset.problem import RepSetExperiment
+from energy_repset.context import ProblemContext
+
+
+class TestHullClusteringSearch:
+
+    def test_basic_run_convex(self, context_with_features):
+        search = HullClusteringSearch(k=2, hull_type='convex')
+        result = search.find_selection(context_with_features)
+
+        assert result is not None
+        assert len(result.selection) == 2
+        assert result.weights is None
+        assert 'projection_error' in result.scores
+        assert result.scores['projection_error'] >= 0.0
+        assert result.selection_space == 'subset'
+
+    def test_basic_run_conic(self, context_with_features):
+        search = HullClusteringSearch(k=2, hull_type='conic')
+        result = search.find_selection(context_with_features)
+
+        assert len(result.selection) == 2
+        assert result.weights is None
+        assert result.scores['projection_error'] >= 0.0
+
+    def test_representatives_dict(self, context_with_features):
+        search = HullClusteringSearch(k=2)
+        result = search.find_selection(context_with_features)
+
+        assert len(result.representatives) == 2
+        for label, df in result.representatives.items():
+            assert label in result.selection
+            assert len(df) > 0
+
+    def test_selection_unique(self, context_with_features):
+        search = HullClusteringSearch(k=2)
+        result = search.find_selection(context_with_features)
+        assert len(set(result.selection)) == len(result.selection)
+
+    def test_convex_error_leq_conic(self, context_with_features):
+        convex = HullClusteringSearch(k=2, hull_type='convex')
+        conic = HullClusteringSearch(k=2, hull_type='conic')
+        r_convex = convex.find_selection(context_with_features)
+        r_conic = conic.find_selection(context_with_features)
+
+        # Conic is less constrained, so error should be <= convex
+        assert r_conic.scores['projection_error'] <= r_convex.scores['projection_error'] + 1e-6
+
+    def test_more_k_reduces_error(self, context_with_features):
+        r1 = HullClusteringSearch(k=1).find_selection(context_with_features)
+        r2 = HullClusteringSearch(k=2).find_selection(context_with_features)
+        assert r2.scores['projection_error'] <= r1.scores['projection_error'] + 1e-6
+
+
+@pytest.mark.integration
+class TestHullClusteringIntegration:
+
+    def test_full_workflow_with_blended(self, df_raw_hourly, monthly_slicer):
+        context = ProblemContext(df_raw=df_raw_hourly, slicer=monthly_slicer)
+        workflow = Workflow(
+            feature_engineer=StandardStatsFeatureEngineer(),
+            search_algorithm=HullClusteringSearch(k=2, hull_type='convex'),
+            representation_model=BlendedRepresentationModel(blend_type='convex'),
+        )
+        experiment = RepSetExperiment(context, workflow)
+        result = experiment.run()
+
+        assert len(result.selection) == 2
+        assert result.weights is not None
+        assert result.weights.shape[0] == 3  # 3 months
+        assert result.weights.shape[1] == 2  # 2 representatives


### PR DESCRIPTION
## Summary
- Implements `HullClusteringSearch`, a greedy forward-selection algorithm that minimizes total projection error by selecting k hull vertices in feature space
- Supports both `convex` (weights >= 0, sum = 1) and `conic` (weights >= 0) projection types
- Leaves `weights=None` for pairing with `BlendedRepresentationModel` (R_soft)
- Based on Bahl et al. (2025), arXiv:2508.21641

## Files
- `energy_repset/search_algorithms/hull_clustering.py` (new)
- `tests/search_algorithms/test_hull_clustering.py` (new, 7 tests)
- `energy_repset/search_algorithms/__init__.py` (export)
- `energy_repset/__init__.py` (top-level export)

## Test plan
- [x] 7 unit tests: basic run (convex/conic), representatives dict, selection uniqueness, conic <= convex error, more k reduces error
- [x] 1 integration test: full workflow with `BlendedRepresentationModel`
- [x] Existing tests pass (no regressions)