### PR TITLE
Add Snippet search algorithm and DirectProfileFeatureEngineer

### DIFF
--- a/energy_repset/__init__.py
+++ b/energy_repset/__init__.py
@@ -18,6 +18,7 @@ from .feature_engineering import (
     FeaturePipeline,
     StandardStatsFeatureEngineer,
     PCAFeatureEngineer,
+    DirectProfileFeatureEngineer,
 )
 
 from .score_components import (
@@ -54,6 +55,7 @@ from .search_algorithms import (
     SearchAlgorithm,
     ObjectiveDrivenSearchAlgorithm,
     ObjectiveDrivenCombinatorialSearchAlgorithm,
+    SnippetSearch,
 )
 
 from .representation import (
@@ -77,6 +79,7 @@ __all__ = [
     "FeaturePipeline",
     "StandardStatsFeatureEngineer",
     "PCAFeatureEngineer",
+    "DirectProfileFeatureEngineer",
     # Score components
     "WassersteinFidelity",
     "CorrelationFidelity",
@@ -105,6 +108,7 @@ __all__ = [
     "SearchAlgorithm",
     "ObjectiveDrivenSearchAlgorithm",
     "ObjectiveDrivenCombinatorialSearchAlgorithm",
+    "SnippetSearch",
     # Representation models
     "RepresentationModel",
     "UniformRepresentationModel",

--- a/energy_repset/feature_engineering/__init__.py
+++ b/energy_repset/feature_engineering/__init__.py
@@ -1,6 +1,7 @@
 from .base_feature_engineer import FeatureEngineer, FeaturePipeline
 from .standard_stats import StandardStatsFeatureEngineer
 from .pca import PCAFeatureEngineer
+from .direct_profile import DirectProfileFeatureEngineer
 
 __all__ = [
     "FeatureEngineer",
@@ -8,4 +9,5 @@ __all__ = [
 
     "StandardStatsFeatureEngineer",
     "PCAFeatureEngineer",
+    "DirectProfileFeatureEngineer",
 ]

--- a/energy_repset/feature_engineering/direct_profile.py
+++ b/energy_repset/feature_engineering/direct_profile.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Optional, Dict, TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from .base_feature_engineer import FeatureEngineer
+
+if TYPE_CHECKING:
+    from ..context import ProblemContext
+
+
+class DirectProfileFeatureEngineer(FeatureEngineer):
+    """Feature engineer that uses raw profile vectors directly (F_direct).
+
+    For each slice, concatenates the raw hourly values across all variables
+    into a single flat feature vector. This preserves the full temporal shape
+    of each period, making it suitable for algorithms that compare time-series
+    profiles directly (e.g., Snippet Algorithm, DTW-based methods).
+
+    Args:
+        variable_weights: Optional dict mapping column names to scalar weights.
+            Weighted columns are multiplied by their weight before flattening.
+            Columns not in the dict are included with weight 1.0.
+
+    Examples:
+        Basic usage with daily slicing:
+
+        >>> from energy_repset.feature_engineering import DirectProfileFeatureEngineer
+        >>> engineer = DirectProfileFeatureEngineer()
+        >>> context_with_features = engineer.run(context)
+        >>> context_with_features.df_features.shape
+        (365, 72)  # 365 days x (24 hours * 3 variables)
+    """
+
+    def __init__(self, variable_weights: Optional[Dict[str, float]] = None):
+        """Initialize direct profile feature engineer.
+
+        Args:
+            variable_weights: Optional mapping of variable names to weights.
+                Variables not in the dict receive weight 1.0.
+        """
+        self.variable_weights = variable_weights or {}
+
+    def calc_and_get_features_df(self, context: ProblemContext) -> pd.DataFrame:
+        """Flatten each slice's raw values into a single feature row.
+
+        Args:
+            context: Problem context with raw time-series data.
+
+        Returns:
+            DataFrame where each row is one slice and columns are the
+            flattened hourly values (hours x variables).
+        """
+        df = context.df_raw.select_dtypes(include=[np.number]).copy()
+
+        for col, w in self.variable_weights.items():
+            if col in df.columns:
+                df[col] = df[col] * w
+
+        slice_labels = context.slicer.labels_for_index(df.index)
+        unique_slices = context.slicer.unique_slices(df.index)
+
+        rows = []
+        for s in unique_slices:
+            mask = slice_labels == s
+            chunk = df.loc[mask]
+            flat = chunk.values.flatten(order='C')
+            rows.append(flat)
+
+        max_len = max(len(r) for r in rows)
+        padded = []
+        for r in rows:
+            if len(r) < max_len:
+                r = np.pad(r, (0, max_len - len(r)), constant_values=np.nan)
+            padded.append(r)
+
+        col_names = [f"t{i}" for i in range(max_len)]
+        return pd.DataFrame(padded, index=unique_slices, columns=col_names)

--- a/energy_repset/search_algorithms/__init__.py
+++ b/energy_repset/search_algorithms/__init__.py
@@ -1,8 +1,10 @@
 from .search_algorithm import SearchAlgorithm
 from .objective_driven import ObjectiveDrivenSearchAlgorithm, ObjectiveDrivenCombinatorialSearchAlgorithm
+from .snippet import SnippetSearch
 
 __all__ = [
     "SearchAlgorithm",
     "ObjectiveDrivenSearchAlgorithm",
     "ObjectiveDrivenCombinatorialSearchAlgorithm",
+    "SnippetSearch",
 ]

--- a/energy_repset/search_algorithms/snippet.py
+++ b/energy_repset/search_algorithms/snippet.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from .search_algorithm import SearchAlgorithm
+from ..results import RepSetResult
+
+if TYPE_CHECKING:
+    from ..context import ProblemContext
+
+
+class SnippetSearch(SearchAlgorithm):
+    """Greedy p-median selection of multi-day representative subsequences.
+
+    Implements the Snippet algorithm from Teichgraeber & Brandt (2024).
+    Selects k sliding-window subsequences of ``period_length_days`` days each,
+    minimizing the total day-level distance across the full time horizon.
+
+    Each candidate subsequence contains ``period_length_days`` daily profile
+    snippets. The distance from any day to a candidate is the minimum
+    Euclidean distance to any of its constituent daily snippets. The greedy
+    selection picks the candidate with the greatest total cost reduction at
+    each iteration.
+
+    Requires ``context.slicer.unit == 'day'``.
+
+    Args:
+        k: Number of representative subsequences to select.
+        period_length_days: Length of each candidate subsequence in days.
+        step_days: Stride between consecutive sliding-window candidates.
+
+    Examples:
+        Basic usage with daily slicing:
+
+        >>> from energy_repset.search_algorithms import SnippetSearch
+        >>> from energy_repset.time_slicer import TimeSlicer
+        >>> slicer = TimeSlicer(unit='day')
+        >>> search = SnippetSearch(k=8, period_length_days=7, step_days=1)
+    """
+
+    def __init__(
+        self, k: int, period_length_days: int = 7, step_days: int = 1,
+    ):
+        """Initialize Snippet search.
+
+        Args:
+            k: Number of representative subsequences to select.
+            period_length_days: Number of days in each candidate subsequence.
+            step_days: Stride between consecutive candidate start positions.
+        """
+        self.k = k
+        self.period_length_days = period_length_days
+        self.step_days = step_days
+
+    def find_selection(self, context: ProblemContext) -> RepSetResult:
+        """Find k representative subsequences via greedy p-median selection.
+
+        Args:
+            context: Problem context. Must have ``slicer.unit == 'day'``.
+                Feature engineering should provide daily profile vectors in
+                ``df_features``, but the algorithm can also build profiles
+                from ``df_raw`` directly.
+
+        Returns:
+            RepSetResult with selected starting-day labels, pre-computed
+            weights (fraction of days assigned), and total distance score.
+
+        Raises:
+            ValueError: If ``context.slicer.unit`` is not ``'day'``.
+        """
+        if context.slicer.unit != 'day':
+            raise ValueError(
+                f"SnippetSearch requires daily slicing (unit='day'), "
+                f"got unit='{context.slicer.unit}'."
+            )
+
+        daily_profiles = self._build_daily_profiles(context)
+        N = daily_profiles.shape[0]
+        day_labels = list(context.df_features.index)
+        L = self.period_length_days
+
+        candidates = self._generate_candidates(N, L, self.step_days)
+        if len(candidates) < self.k:
+            raise ValueError(
+                f"Only {len(candidates)} candidate subsequences available, "
+                f"but k={self.k} requested. Reduce k or period_length_days."
+            )
+
+        dist_matrix = self._compute_distance_matrix(daily_profiles, candidates)
+
+        selected_candidates, per_day_min = self._greedy_select(
+            dist_matrix, self.k
+        )
+
+        assignments = np.argmin(
+            dist_matrix[:, selected_candidates], axis=1
+        )
+
+        selection_labels = []
+        weight_dict = {}
+        for local_idx, cand_idx in enumerate(selected_candidates):
+            start_day = candidates[cand_idx][0]
+            label = day_labels[start_day]
+            selection_labels.append(label)
+            n_assigned = int(np.sum(assignments == local_idx))
+            weight_dict[label] = n_assigned / N
+
+        selection = tuple(selection_labels)
+        total_distance = float(np.sum(per_day_min))
+
+        slice_labels = context.slicer.labels_for_index(context.df_raw.index)
+        representatives = {}
+        for label in selection:
+            start_idx = day_labels.index(label)
+            end_idx = min(start_idx + L, N)
+            period_labels = day_labels[start_idx:end_idx]
+            mask = slice_labels.isin(set(period_labels))
+            representatives[label] = context.df_raw.loc[mask]
+
+        return RepSetResult(
+            context=context,
+            selection_space='subset',
+            selection=selection,
+            scores={'total_distance': total_distance},
+            representatives=representatives,
+            weights=weight_dict,
+            diagnostics={
+                'assignments': assignments.tolist(),
+                'candidate_starts': [
+                    day_labels[candidates[c][0]] for c in selected_candidates
+                ],
+            },
+        )
+
+    def _build_daily_profiles(self, context: ProblemContext) -> np.ndarray:
+        """Build daily profile vectors from context features.
+
+        Args:
+            context: Problem context with ``df_features`` populated.
+
+        Returns:
+            Array of shape (N_days, n_features) with one row per day.
+        """
+        return context.df_features.values
+
+    def _generate_candidates(
+        self, n_days: int, length: int, step: int
+    ) -> list[list[int]]:
+        """Generate sliding-window candidate subsequences.
+
+        Args:
+            n_days: Total number of days.
+            length: Number of days per subsequence.
+            step: Stride between consecutive candidates.
+
+        Returns:
+            List of candidates, each a list of day indices.
+        """
+        candidates = []
+        start = 0
+        while start + length <= n_days:
+            candidates.append(list(range(start, start + length)))
+            start += step
+        return candidates
+
+    def _compute_distance_matrix(
+        self, profiles: np.ndarray, candidates: list[list[int]]
+    ) -> np.ndarray:
+        """Compute distance from each day to each candidate.
+
+        For each (day, candidate) pair, the distance is the minimum Euclidean
+        distance between the day's profile and any of the candidate's daily
+        snippet profiles.
+
+        Args:
+            profiles: Daily profile matrix (N x p).
+            candidates: List of candidate subsequences (each a list of day indices).
+
+        Returns:
+            Distance matrix of shape (N, C) where C is the number of candidates.
+        """
+        N = profiles.shape[0]
+        C = len(candidates)
+        dist_matrix = np.empty((N, C))
+
+        for j, cand_days in enumerate(candidates):
+            cand_profiles = profiles[cand_days]
+            for i in range(N):
+                diffs = cand_profiles - profiles[i]
+                dists = np.sum(diffs ** 2, axis=1)
+                dist_matrix[i, j] = np.min(dists)
+
+        return dist_matrix
+
+    def _greedy_select(
+        self, dist_matrix: np.ndarray, k: int
+    ) -> tuple[list[int], np.ndarray]:
+        """Greedy p-median selection of k candidates.
+
+        At each iteration, selects the candidate that most reduces the total
+        per-day minimum distance.
+
+        Args:
+            dist_matrix: Distance matrix (N x C).
+            k: Number of candidates to select.
+
+        Returns:
+            Tuple of (selected candidate indices, per-day minimum distances).
+        """
+        N = dist_matrix.shape[0]
+        per_day_min = np.full(N, np.inf)
+        selected: list[int] = []
+
+        for _ in range(k):
+            best_candidate = -1
+            best_reduction = -np.inf
+
+            for j in range(dist_matrix.shape[1]):
+                if j in selected:
+                    continue
+                new_min = np.minimum(per_day_min, dist_matrix[:, j])
+                reduction = np.sum(per_day_min) - np.sum(new_min)
+                if reduction > best_reduction:
+                    best_reduction = reduction
+                    best_candidate = j
+
+            selected.append(best_candidate)
+            per_day_min = np.minimum(per_day_min, dist_matrix[:, best_candidate])
+
+        return selected, per_day_min

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 from energy_repset.time_slicer import TimeSlicer
 from energy_repset.context import ProblemContext
-from energy_repset.feature_engineering import StandardStatsFeatureEngineer
+from energy_repset.feature_engineering import StandardStatsFeatureEngineer, DirectProfileFeatureEngineer
 
 
 @pytest.fixture(scope="session")
@@ -101,3 +101,8 @@ def context_daily_with_stats_features(context_daily) -> ProblemContext:
     return engineer.run(context_daily)
 
 
+@pytest.fixture(scope="session")
+def context_daily_with_direct_features(context_daily) -> ProblemContext:
+    """Daily ProblemContext with df_features via DirectProfileFeatureEngineer."""
+    engineer = DirectProfileFeatureEngineer()
+    return engineer.run(context_daily)

--- a/tests/search_algorithms/test_snippet.py
+++ b/tests/search_algorithms/test_snippet.py
@@ -1,0 +1,94 @@
+"""Tests for Snippet search algorithm."""
+import pytest
+
+from energy_repset.search_algorithms import SnippetSearch
+from energy_repset.feature_engineering import DirectProfileFeatureEngineer
+from energy_repset.representation import UniformRepresentationModel
+from energy_repset.workflow import Workflow
+from energy_repset.problem import RepSetExperiment
+from energy_repset.context import ProblemContext
+from energy_repset.time_slicer import TimeSlicer
+
+
+class TestSnippetSearch:
+
+    def test_basic_run(self, context_daily_with_direct_features):
+        search = SnippetSearch(k=2, period_length_days=7, step_days=7)
+        result = search.find_selection(context_daily_with_direct_features)
+
+        assert result is not None
+        assert len(result.selection) == 2
+        assert result.selection_space == 'subset'
+
+    def test_weights_sum_to_one(self, context_daily_with_direct_features):
+        search = SnippetSearch(k=2, period_length_days=7, step_days=7)
+        result = search.find_selection(context_daily_with_direct_features)
+
+        assert result.weights is not None
+        assert sum(result.weights.values()) == pytest.approx(1.0)
+
+    def test_weights_keys_match_selection(self, context_daily_with_direct_features):
+        search = SnippetSearch(k=2, period_length_days=7, step_days=7)
+        result = search.find_selection(context_daily_with_direct_features)
+
+        assert set(result.weights.keys()) == set(result.selection)
+
+    def test_total_distance_score(self, context_daily_with_direct_features):
+        search = SnippetSearch(k=2, period_length_days=7, step_days=7)
+        result = search.find_selection(context_daily_with_direct_features)
+
+        assert 'total_distance' in result.scores
+        assert result.scores['total_distance'] >= 0.0
+
+    def test_representatives_dict(self, context_daily_with_direct_features):
+        search = SnippetSearch(k=2, period_length_days=7, step_days=7)
+        result = search.find_selection(context_daily_with_direct_features)
+
+        assert len(result.representatives) == 2
+        for label, df in result.representatives.items():
+            assert label in result.selection
+            assert len(df) > 0
+
+    def test_more_k_reduces_distance(self, context_daily_with_direct_features):
+        r1 = SnippetSearch(k=2, period_length_days=7, step_days=7).find_selection(
+            context_daily_with_direct_features
+        )
+        r2 = SnippetSearch(k=4, period_length_days=7, step_days=7).find_selection(
+            context_daily_with_direct_features
+        )
+        assert r2.scores['total_distance'] <= r1.scores['total_distance'] + 1e-6
+
+    def test_rejects_non_daily_slicer(self, context_with_features):
+        search = SnippetSearch(k=2, period_length_days=7)
+        with pytest.raises(ValueError, match="daily slicing"):
+            search.find_selection(context_with_features)
+
+    def test_step_days_parameter(self, context_daily_with_direct_features):
+        search = SnippetSearch(k=2, period_length_days=7, step_days=1)
+        result = search.find_selection(context_daily_with_direct_features)
+        assert len(result.selection) == 2
+
+    def test_diagnostics(self, context_daily_with_direct_features):
+        search = SnippetSearch(k=2, period_length_days=7, step_days=7)
+        result = search.find_selection(context_daily_with_direct_features)
+
+        assert 'assignments' in result.diagnostics
+        assert 'candidate_starts' in result.diagnostics
+
+
+@pytest.mark.integration
+class TestSnippetIntegration:
+
+    def test_full_workflow(self, df_raw_hourly, daily_slicer):
+        context = ProblemContext(df_raw=df_raw_hourly, slicer=daily_slicer)
+        workflow = Workflow(
+            feature_engineer=DirectProfileFeatureEngineer(),
+            search_algorithm=SnippetSearch(k=3, period_length_days=7, step_days=7),
+            representation_model=UniformRepresentationModel(),
+        )
+        experiment = RepSetExperiment(context, workflow)
+        result = experiment.run()
+
+        assert len(result.selection) == 3
+        assert result.weights is not None
+        assert sum(result.weights.values()) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- Implements `SnippetSearch`, a greedy p-median selection of multi-day representative subsequences using day-level snippet distance
- Implements `DirectProfileFeatureEngineer` (F_direct), which flattens raw hourly values per slice into feature vectors -- needed for the Snippet workflow and useful for any profile-based comparison
- Pre-computes weights (fraction of days assigned), so the external `RepresentationModel` is skipped
- Based on Teichgraeber & Brandt (2024), arXiv:2401.02888

## Files
- `energy_repset/search_algorithms/snippet.py` (new)
- `energy_repset/feature_engineering/direct_profile.py` (new)
- `tests/search_algorithms/test_snippet.py` (new, 10 tests)
- `tests/conftest.py` (add `DirectProfileFeatureEngineer` import + `context_daily_with_direct_features` fixture)
- `energy_repset/search_algorithms/__init__.py` (export)
- `energy_repset/feature_engineering/__init__.py` (export)
- `energy_repset/__init__.py` (top-level exports)

## Test plan
- [x] 9 unit tests: basic run, weights sum to 1, keys match selection, total_distance score, representatives, more k reduces distance, rejects non-daily slicer, step_days parameter, diagnostics
- [x] 1 integration test: full workflow with `DirectProfileFeatureEngineer` + `SnippetSearch`
- [x] Existing tests pass (no regressions)